### PR TITLE
Discord emoji support: electric boogalo

### DIFF
--- a/src/lib/discordEmoji.ts
+++ b/src/lib/discordEmoji.ts
@@ -48,6 +48,8 @@ export const discordEmoji = [
   "<:shakespeare:982709311702716457>",
   "<:sus:1199167654972375090>",
   "<:zed:1208625071766114364>",
+  "<:cry:1191308272372822026>",
+  "<:dapperfella:1046599703795597342>",
 ].map((emoji) => {
   const match = emoji.match(DISCORD_REGEX);
   if (!match) {

--- a/src/lib/discordEmoji.ts
+++ b/src/lib/discordEmoji.ts
@@ -47,6 +47,7 @@ export const discordEmoji = [
   "<:wow:952755842095132752>",
   "<:shakespeare:982709311702716457>",
   "<:sus:1199167654972375090>",
+  "<:zed:1208625071766114364>",
 ].map((emoji) => {
   const match = emoji.match(DISCORD_REGEX);
   if (!match) {

--- a/src/lib/discordEmoji.ts
+++ b/src/lib/discordEmoji.ts
@@ -48,7 +48,6 @@ export const discordEmoji = [
   "<:shakespeare:982709311702716457>",
   "<:sus:1199167654972375090>",
   "<:zed:1208625071766114364>",
-  "<:cry:1191308272372822026>",
   "<:dapperfella:1046599703795597342>",
 ].map((emoji) => {
   const match = emoji.match(DISCORD_REGEX);


### PR DESCRIPTION
Adds "<:zed:1208625071766114364>" (![zed](https://cdn.discordapp.com/emojis/1208625071766114364.webp?size=24&quality=lossless))
and another