### PR TITLE
[I18N] Correct `deleteAccountPassword` to `deleteAccountPasswordPrompt` to show proper string

### DIFF
--- a/src/components/locations/Settings.vue
+++ b/src/components/locations/Settings.vue
@@ -178,7 +178,7 @@ const deleteAccount = async () => {
     return;
   }
   const password = await dialogStore.prompt(
-    t("deleteAccountPassword"),
+    t("deleteAccountPasswordPrompt"),
     t("deleteAccountPasswordPlaceholder"),
     { password: true },
   );


### PR DESCRIPTION
![kép](https://github.com/mybearworld/roarer/assets/150537842/c3ea6dc4-22a8-4243-bf3d-6e4512920c0d)
This is because it's internalized as `deleteAccountPasswordPrompt`, not `deleteAccountPassword`.

[line 72 of the i18n proves that as such](https://github.com/mybearworld/roarer/blob/6a38843ef0851a725a8558cd92d1c865b9029aac/src/i18n/en.ts#L72)